### PR TITLE
Fix packet-validation regressions and unload state restoration

### DIFF
--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -569,7 +569,7 @@ namespace hooks {
 			
 			bool result = LobbyMsgRW_PackageInt(lobbyMsg, key, val);
 
-			if ( result && !Protection::I_stricmp(key, "lobbytype") || !Protection::I_stricmp(key, "srclobbytype") || !Protection::I_stricmp(key, "destlobbytype"))
+			if (result && (!Protection::I_stricmp(key, "lobbytype") || !Protection::I_stricmp(key, "srclobbytype") || !Protection::I_stricmp(key, "destlobbytype")))
 			{
 				if (*val < 0 || *val > 1)
 				{
@@ -577,7 +577,7 @@ namespace hooks {
 					return false;
 				}
 			}
-			return true;
+			return result;
 		}
 
 		bool hkLobbyMsgRW_PackageUInt(LobbyMsg* lobbyMsg, const char* key, unsigned __int32* val)

--- a/Protection.cpp
+++ b/Protection.cpp
@@ -219,7 +219,7 @@ bool Protection::ReadP2PPacket(uintptr_t thisptr, void* pub_dest, unsigned int c
 
 	bool result = ((bool(__fastcall*)(uintptr_t, void*, unsigned int, unsigned int*, uint64_t*, int))GetOriginalSteamPtr(STEAMAPI_NETWORKING, STEAMAPI_NETWORKING_READP2PPACKET))(thisptr, pub_dest, cub_dest, cub_msg_size, steam_id_remote, n_channel);
 
-    if (result) {
+    if (result && cub_msg_size && *cub_msg_size > 5) {
 
         char* data = reinterpret_cast<char*>(pub_dest);
 
@@ -1016,7 +1016,7 @@ void Protection::install()
 
 void Protection::uninstall()
 {
-    *(__int64*)PTR_lobbymsgprints = *(__int64*)PTR_lobbymsgprints;
+    *(__int64*)PTR_lobbymsgprints = Protection::Old_lobbymsgprints;
     SetNetworkPassword(0);
     Iat_hook_::detour_iat_ptr("IsProcessorFeaturePresent", (void*)old_IsProcessorFeaturePresent);
 


### PR DESCRIPTION
## Summary
Three correctness/security fixes found during a static review. All are minimal and mirror existing patterns already in the codebase. AI was used as part of this review however the change made are mine and the small finds it had found I agreed with all.

1. **`hkLobbyMsgRW_PackageInt` defeated its own validation**:  An operator precedence slip and an unconditional `return true` meant the game's internal integer field reads were always reported as successful, suppressing its own malformed packet bail out. Now parenthesise and returns the real result, matching the sibling `hkLobbyMsgRW_PackageUInt`.
   
2. **`uninstall()` never restored `lobbymsgprints`**: It self-assigned the poisoned sentinel (`0xFFEEDDCC44332212`) instead of restoring the saved original, leaving the game in a broken state after unload.
   
3. **`ReadP2PPacket` read `data[5]` without a length check**: Short peer packets branched on stale/uninitialised buffer bytes. Added a `*cub_msg_size > 5` guard.

## Testing
I only did a static review, as I am on linux so would of been a bit of a pain and second I do not have VS installed 😄. I would not merge this PR or redo the fixes yourself until you have tested/ ran a build. 

Maybe If I was to make more PRs I would setup more for testing 😄.

## Things I would look into if I was you (not in this PR)
1. **`GetLobbyChatEntry`** recomputes `strlen(msg)` every loop iteration O(n^2) . Trivial for short chat strings, but worth caching the length. Will turn the O(n^2) -> O(n). Very small performance fix but worth the one line change on a larger PR.
  
2. **`hkUI_DoModelStringReplacement`** does `strcpy_s(input, source)` into a `char[4096]` with no length guard, unlike its sibling `hkSEH_ReplaceDirectiveInStringWithBinding` which checks `strlen > 4095` first. If source` can exceed 4095 bytes this can trip the invalid-parameter handler. worth confirming.