### PR TITLE
Filter out broken incentives when spoofing

### DIFF
--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -35,10 +35,26 @@ namespace hooks {
 			return true;
 		}
 
+		// Source: /gamedata/store/common/incentives.csv
 		bool hkLiveEntitlements_IsEntitlementActiveForController(ControllerIndex_t controllerIndex, int incentiveId) {
 
 			#if SPOOF_UNLOCK_ALL
+
+				// Invalid / Duplicates
+				if (incentiveId == 29 || incentiveId == 30 || incentiveId == 34) {
+					return false;
+				}
+
+				#if SPOOF_SKIP_CWL
+
+					if (incentiveId == 21 || incentiveId == 22 || incentiveId == 23) {
+						return false;
+					}
+
+				#endif
+
 				return true;
+
 			#endif
 
 			return LiveEntitlements_IsEntitlementActiveForController(controllerIndex, incentiveId);

--- a/framework.h
+++ b/framework.h
@@ -141,3 +141,4 @@ inline std::vector<std::string> legit_packets = {
 #define ZBR_WINDOW_TEXT "Call of Duty: Black Ops III (community patch by serious)"
 #define ZBR_VERSION_FULL "Patch 3.04 - by serious <3"
 #define SPOOF_UNLOCK_ALL false
+#define SPOOF_SKIP_CWL false


### PR DESCRIPTION
This should fix the issue with the blank CWL calling cards: https://github.com/Scroptss/T7Patch/issues/22 (along with the duplicate CWL camos and the duplicate St. Patrick's calling card).

I've also added a way to filter out all CWL content when spoofing entitlements. I've never been a big fan of them since they take up so much space in the camo menu. I preserved the "CWL Champions Personalization Pack" though.

Also feel free to add this to Scropts-QOL, since I didn't see it there.